### PR TITLE
fix: workspace detection and launch command typos in ap1_setup.sh

### DIFF
--- a/ap1_setup.sh
+++ b/ap1_setup.sh
@@ -36,7 +36,7 @@ echo -e "  Detecting workspace...\n"
 find_workspace() {
     local dir="$1"
     while [[ "$dir" != "/" ]]; do
-        if [[ -d "$dir/src" && -d "$dir/src/perception" ]]; then
+        if [[ -f "$dir/ap1.repos" && -d "$dir/src" ]]; then
             echo "$dir"
             return 0
         fi
@@ -69,7 +69,13 @@ else
 fi
 
 SRC_DIR="$WS_ROOT/src"
-PERCEPTION_DIR="$SRC_DIR/perception"
+if [[ -d "$SRC_DIR/src/perception" ]]; then
+    PERCEPTION_DIR="$SRC_DIR/src/perception"
+elif [[ -d "$SRC_DIR/perception" ]]; then
+    PERCEPTION_DIR="$SRC_DIR/perception"
+else
+    PERCEPTION_DIR="$SRC_DIR/perception"
+fi
 
 # =============================================================================
 # 2. DETECT SHELL & RC FILE
@@ -398,7 +404,7 @@ else
 fi
 
 echo -e "${BOLD}  To launch the full system, open a new terminal and run:${NC}"
-echo -e "  ${CYAN}ros2 launch ap1bringup fullsystem.launch.py${NC}\n"
+echo -e "  ${CYAN}ros2 launch ap1_bringup full_system.launch.py${NC}\n"
 echo -e "${BOLD}  Or for PnC + sim only:${NC}"
-echo -e "  ${CYAN}ros2 launch ap1bringup pncbackend.launch.py${NC}\n"
+echo -e "  ${CYAN}ros2 launch ap1_bringup pncbackend.launch.py${NC}\n"
 echo -e "  ${YELLOW}Note: Open a NEW terminal so the RC file changes take effect.${NC}\n"


### PR DESCRIPTION
## Problem

Running \`./ap1_setup.sh\` from the cloned workspace fails to auto-detect the workspace root, and the final summary prints wrong launch commands.

## Bugs fixed

### 1. Workspace detection always fails

\`find_workspace\` looked for \`\$dir/src/perception\`, but after \`vcs import\` the perception repo lands at \`src/src/perception\` (nested). The script always fell through to the manual prompt.

**Fix:** use \`ap1.repos\` as the workspace marker — it only exists at the true root.

### 2. PERCEPTION_DIR wrong path

\`PERCEPTION_DIR\` was hardcoded to \`\$SRC_DIR/perception\`. After vcs import the actual path is \`\$SRC_DIR/src/perception\`.

**Fix:** probe both paths; fall back to the flat layout for forward-compatibility.

### 3. Launch command typos in final summary

Both echo lines at the end used \`ap1bringup\` (missing underscore) and \`fullsystem\` (missing underscore) — neither is a valid ROS2 package/launch-file name.

**Fix:** \`ap1_bringup full_system.launch.py\` and \`ap1_bringup pncbackend.launch.py\`.

## Test plan

- [ ] Run \`./ap1_setup.sh\` from the cloned workspace root — auto-detects \`WS_ROOT\` without prompting
- [ ] \`uv sync\` runs against \`src/src/perception\`
- [ ] Final summary prints correct launch commands