### PR TITLE
fix: clean up pnc backend bringup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ To use clone then use vcs in ROS2 to pull subrepos.
 `vcs import < ap1.repos`
 
 All teams' code is located under their folder in `src/`.
-Launch code is located in the launch pkg: `src/ap1_launch` and is tracked in THIS repository. This is the only pkg that is tracked in this repository.  
+Launch code is located in the bringup package: `src/bringup` and is tracked in THIS repository. This is the only package tracked directly in this repository.  

--- a/SETUP.md
+++ b/SETUP.md
@@ -104,7 +104,7 @@ ros2 launch ap1_bringup full_system.launch.py
 
 ### Planning, Control & Sim only
 ```bash
-ros2 launch ap1_bringup pncbackend.launch.py
+ros2 launch ap1_bringup pnc_backend.launch.py
 ```
 
 ### Mapping & Localization pipeline only

--- a/ap1_setup.sh
+++ b/ap1_setup.sh
@@ -51,10 +51,10 @@ WS_ROOT=""
 if WS_ROOT=$(find_workspace "$(pwd)"); then
     ok "Found workspace at: $WS_ROOT"
 # 2. Check common locations
-elif [[ -d "$HOME/Documents/ap1/src/perception" ]]; then
+elif [[ -f "$HOME/Documents/ap1/ap1.repos" && -d "$HOME/Documents/ap1/src" ]]; then
     WS_ROOT="$HOME/Documents/ap1"
     ok "Found workspace at: $WS_ROOT"
-elif [[ -d "$HOME/ap1/src/perception" ]]; then
+elif [[ -f "$HOME/ap1/ap1.repos" && -d "$HOME/ap1/src" ]]; then
     WS_ROOT="$HOME/ap1"
     ok "Found workspace at: $WS_ROOT"
 else
@@ -406,5 +406,5 @@ fi
 echo -e "${BOLD}  To launch the full system, open a new terminal and run:${NC}"
 echo -e "  ${CYAN}ros2 launch ap1_bringup full_system.launch.py${NC}\n"
 echo -e "${BOLD}  Or for PnC + sim only:${NC}"
-echo -e "  ${CYAN}ros2 launch ap1_bringup pncbackend.launch.py${NC}\n"
+echo -e "  ${CYAN}ros2 launch ap1_bringup pnc_backend.launch.py${NC}\n"
 echo -e "  ${YELLOW}Note: Open a NEW terminal so the RC file changes take effect.${NC}\n"

--- a/src/bringup/launch/pnc_backend.launch.py
+++ b/src/bringup/launch/pnc_backend.launch.py
@@ -7,7 +7,7 @@ from ament_index_python.packages import get_package_share_directory
 '''
 Run this file initially with ros2 launch ap1_bringup pnc_backend.launch.py 
 
-it will get planning, control and the sim up and running 
+it will get planning and control up and running
 '''
 
 def generate_launch_description():
@@ -31,15 +31,7 @@ def generate_launch_description():
         ],
     )
 
-    sim = Node(
-        package='ap1_pnc_sim',
-        executable='pnc_sim_node',
-        name='sim_node',
-        output='screen',
-    )
-
     return LaunchDescription([
         control,
         TimerAction(period=2.0, actions=[planner]),
-        TimerAction(period=4.0, actions=[sim]),
     ])

--- a/src/bringup/launch/ui_setup.launch.py
+++ b/src/bringup/launch/ui_setup.launch.py
@@ -3,14 +3,14 @@ from launch_ros.actions import Node
 
 ''' 
 honestly unnecessary because you can just use a ros command to run the interface now using this launch command:
-         ros2 launch ap1_bringup ui_only.launch.py 
+         ros2 launch ap1_bringup ui_setup.launch.py
     if you want to run through regularly just run in another terminal:
-        ros2 run ap1_console system_interface
+        ros2 run ap1_console console
 '''
 def generate_launch_description():
     console = Node(
         package='ap1_console',
-        executable='system_interface',
+        executable='console',
         name='ap1_console',
         output='screen',
     )


### PR DESCRIPTION
## Problem

`pnc_backend.launch.py` had a couple of stale bringup references that break or confuse a fresh AP1 workspace:

- Setup/docs referenced `pncbackend.launch.py` instead of the real `pnc_backend.launch.py`.
- `ui_setup.launch.py` referenced stale console executable `system_interface`; the current console entry point is `console`.
- `pnc_backend.launch.py` still described itself as launching sim, but `pnc-sim` is auxiliary and should not be launched from AP1 bringup.

## Changes

- Remove `pnc-sim` from `pnc_backend.launch.py`; the launch now starts only planning and control.
- Fix setup output and docs to use `pnc_backend.launch.py`.
- Fix `ui_setup.launch.py` and comments to use `ap1_console/console`.
- Update stale README bringup path from `src/ap1_launch` to `src/bringup`.
- Make common-location workspace detection use `ap1.repos` + `src/` markers instead of the old flat `src/perception` path.

## Test plan

- [ ] `vcs import src < ap1.repos`
- [ ] `./ap1_setup.sh`
- [ ] `ros2 launch ap1_bringup pnc_backend.launch.py`
- [ ] `ros2 launch ap1_bringup ui_setup.launch.py`

Expected: PnC backend launch starts control and planner without trying to resolve or launch `ap1_pnc_sim`. UI launch starts the console entry point.
