### PR TITLE
fix: keep setup build on ROS python

### DIFF
--- a/ap1_setup.sh
+++ b/ap1_setup.sh
@@ -214,6 +214,13 @@ else
             ERRORS=$((ERRORS+1))
         fi
     done
+
+    # Keep perception dependencies in uv, but do not build ROS packages from
+    # inside that venv. ament/rosidl need the system ROS Python environment.
+    if declare -F deactivate >/dev/null; then
+        deactivate
+        ok "Perception venv deactivated before ROS build"
+    fi
 fi
 
 # =============================================================================
@@ -253,7 +260,7 @@ else
     info "Architecture detected: $ARCH"
 
     # Base skip keys — perception Python deps are fully managed by uv, not rosdep
-    SKIP_KEYS="ap1_perception ultralytics onnxruntime opencv-python torch pyqt5 pyqt6"
+    SKIP_KEYS="ap1_perception ultralytics onnxruntime opencv-python torch pyqt5 pyqt6 python3-pyqt6"
 
     # ARM64-specific: pyrealsense2 and several perception packages
     # have no Jazzy aarch64 apt binaries available
@@ -313,22 +320,27 @@ fi
 step "Building the workspace with colcon"
 
 info "Building from $WS_ROOT ..."
+BUILD_OK=false
 (
     cd "$WS_ROOT"
+    unset VIRTUAL_ENV
+    unset PYTHONHOME
     set +u  # ROS2 setup.bash uses unbound vars (AMENT_TRACE_SETUP_FILES)
     source "$ROS_SETUP"
     set -u
     colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release 2>&1 | \
+        tee /tmp/ap1_colcon_build.log | \
         grep -E "(Starting|Finished|Failed|Error|error:|warning:)" || true
-)
+    exit "${PIPESTATUS[0]}"
+) && BUILD_OK=true
 
-if [[ -f "$WS_ROOT/install/setup.bash" ]]; then
-    ok "Build succeeded — install/setup.bash exists"
+if $BUILD_OK && [[ -f "$WS_ROOT/install/setup.bash" ]]; then
+    ok "Build succeeded"
     set +u
     source "$WS_ROOT/install/setup.bash"
     set -u
 else
-    err "Build may have failed — install/setup.bash not found"
+    err "Build failed - review /tmp/ap1_colcon_build.log"
     ERRORS=$((ERRORS+1))
 fi
 


### PR DESCRIPTION
Problem
ap1_setup.sh could report success while the workspace build had actually failed on a fresh Ubuntu 24.04 / ROS Jazzy WSL setup:

- The script activated the perception uv venv, then ran colcon from inside that venv. ament/rosidl then used the venv Python and failed to import ROS system packages such as em/ament_package.
- rosdep attempted to resolve python3-pyqt6 for ap1_console, but this key is not available through rosdep in this environment. The script already handles PyQt6 separately, so this should be skipped like the other Python deps managed outside rosdep.
- The colcon output pipeline ended in grep || true, so a failed build could still continue and be treated as success if an old install/setup.bash existed.

Changes
- Deactivate the perception uv venv before the ROS workspace build.
- Unset VIRTUAL_ENV/PYTHONHOME and source ROS inside the colcon build subshell.
- Skip python3-pyqt6 during rosdep install.
- Preserve the real colcon exit code while still filtering logs, and write the full build log to /tmp/ap1_colcon_build.log.
- Only report build success when colcon succeeds and install/setup.bash exists.

Test plan
- bash -n ap1_setup.sh
- Reproduced the original WSL setup failure locally, then verified the manual workaround builds when using the system ROS Python environment.

Context
This came out of setting up AP1 on Luke's Ubuntu 24.04 WSL machine with ROS Jazzy, uv, colcon, vcs, and rosdep.