### PR TITLE
docs: add RealSense bag replay steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # AP1 | 2025-6
 
-This is WE Autopilot's master workspace for development.
+This is WE Autopilot's master workspace for development of the self-driving car system called AP1.
 
-To use clone then use vcs in ROS2 to pull subrepos.
-`vcs import < ap1.repos`
+For setup see SETUP.md.
 
-All teams' code is located under their folder in `src/`.
-Launch code is located in the bringup package: `src/bringup` and is tracked in THIS repository. This is the only package tracked directly in this repository.  
+## Repo Structure
+
+Under `src` find dirs for:
+- bringup (launching ap1 in ROS2)
+- msgs (communication between subsystems)
+
+As well as for each subsystem:
+- perception
+- mapping_and_localization
+- planning_and_control

--- a/SETUP.md
+++ b/SETUP.md
@@ -102,7 +102,7 @@ source ~/Documents/ap1/install/setup.bash
 ros2 launch ap1_bringup full_system.launch.py
 ```
 
-### Planning, Control & Sim only
+### Planning & Control only
 ```bash
 ros2 launch ap1_bringup pnc_backend.launch.py
 ```
@@ -125,7 +125,39 @@ ros2 run ap1_console console
 
 ---
 
-## 7. Verify Everything is Running
+## 7. Replay a Recorded RealSense Bag
+
+RealSense `.bag` files are not ROS2 bags, so replay them through
+`realsense2_camera` instead of `ros2 bag play`.
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source ~/Documents/ap1/install/setup.bash
+
+ros2 launch realsense2_camera rs_launch.py \
+  rosbag_filename:=/absolute/path/to/recording.bag \
+  align_depth.enable:=true \
+  pointcloud.enable:=true \
+  rosbag_loop:=false
+```
+
+Use `pointcloud.enable:=true` so perception nodes that subscribe to
+`/camera/camera/depth/color/points` receive data. Prefer `rosbag_loop:=false`
+for integration testing; looping can replay/reset quickly and make logs hard to
+read.
+
+Quick topic checks:
+
+```bash
+ros2 topic hz /camera/camera/color/image_raw
+ros2 topic hz /camera/camera/depth/color/points
+ros2 topic echo --once /ap1/perception/lanes
+ros2 topic echo --once /ap1/mapping/lanes
+```
+
+---
+
+## 8. Verify Everything is Running
 
 ```bash
 # List all active nodes

--- a/SETUP.md
+++ b/SETUP.md
@@ -23,11 +23,15 @@ chmod +x ap1_setup.sh
 ## 1. Clone the Workspace
 
 ```bash
-mkdir -p ~/Documents/ap1/src
-cd ~/Documents/ap1/src
+mkdir -p ~/Documents/ap1
+cd ~/Documents/ap1
 
 vcs import < ap1.repos
 ```
+
+Run `vcs import` from the workspace root. The paths in `ap1.repos` already
+include `src/`, so importing from inside `src/` creates nested paths such as
+`src/src/perception`.
 
 ---
 


### PR DESCRIPTION
﻿Problem
During AP1 bringup, replaying the recorded RealSense D455 .bag was easy to confuse with ROS2 bag playback. The perception pipeline also needs the aligned depth/point cloud topics enabled explicitly.

Changes
- Add SETUP.md steps for replaying a RealSense .bag through realsense2_camera.
- Document align_depth.enable:=true, pointcloud.enable:=true, and rosbag_loop:=false.
- Add quick topic checks for camera image, point cloud, perception lanes, and mapping lanes.
- Rename the PnC launch heading from "Planning, Control & Sim" to "Planning & Control" since AP1 bringup no longer launches pnc-sim there.

Test plan
- git diff --check
- Commands are based on the RealSense D455 bag replay used during WSL/Jazzy AP1 bringup.
