### PR TITLE
feat: add software smoke test launch flags

### DIFF
--- a/src/bringup/launch/full_system.launch.py
+++ b/src/bringup/launch/full_system.launch.py
@@ -1,7 +1,10 @@
-import os 
+import os
+
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, Shutdown
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch.actions import Shutdown, IncludeLaunchDescription
 from ament_index_python.packages import get_package_share_directory
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
@@ -9,6 +12,11 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 This file kinda works, but because of the logs of the other packages, it screws up the interface itself, not being able to click
 '''
 def generate_launch_description():
+    use_synthetic_actuation_feedback = LaunchConfiguration(
+        'use_synthetic_actuation_feedback'
+    )
+    use_synthetic_odometry = LaunchConfiguration('use_synthetic_odometry')
+
     # Helper so that a failure in this node takes down all of AP1 instead of just continuing
     def CriticalNode(**kwargs):
         return Node(on_exit=Shutdown(), **kwargs)
@@ -25,6 +33,13 @@ def generate_launch_description():
         arguments=[
             csv_file_path
         ],
+    )
+    synthetic_actuation_feedback = Node(
+        package='ap1_control',
+        executable='synthetic_actuation_feedback_node',
+        name='synthetic_actuation_feedback',
+        output='screen',
+        condition=IfCondition(use_synthetic_actuation_feedback),
     )
 
     # == PLANNER NODE ==
@@ -70,11 +85,27 @@ def generate_launch_description():
                 'launch',
                 'mapping_pipeline.launch.py'
             )
-        )
+        ),
+        launch_arguments={
+            'use_synthetic_odometry': use_synthetic_odometry,
+        }.items(),
     )
 
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_synthetic_actuation_feedback',
+            default_value='false',
+            description=(
+                'Publish fake /ap1/actuation feedback for smoke tests.'
+            ),
+        ),
+        DeclareLaunchArgument(
+            'use_synthetic_odometry',
+            default_value='false',
+            description='Forward synthetic odometry flag to mapping launch.',
+        ),
         control,
+        synthetic_actuation_feedback,
         planner,
         yolo,
         ufld_ground,

--- a/src/bringup/launch/full_system.launch.py
+++ b/src/bringup/launch/full_system.launch.py
@@ -3,6 +3,7 @@ import os
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, Shutdown
 from launch.conditions import IfCondition
+from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
@@ -16,6 +17,7 @@ def generate_launch_description():
         'use_synthetic_actuation_feedback'
     )
     use_synthetic_odometry = LaunchConfiguration('use_synthetic_odometry')
+    use_synthetic_perception = LaunchConfiguration('use_synthetic_perception')
 
     # Helper so that a failure in this node takes down all of AP1 instead of just continuing
     def CriticalNode(**kwargs):
@@ -61,12 +63,14 @@ def generate_launch_description():
         executable='yolo_node',
         name='ap1_yolo',
         output='log',
+        condition=UnlessCondition(use_synthetic_perception),
     )
     ufld_ground = CriticalNode(
         package='ap1_perception',
         executable='ufld_ground_node',
         name='ap1_ufld_ground',
         output='log',
+        condition=UnlessCondition(use_synthetic_perception),
     )
 
     # == CONSOLE NODE ==
@@ -87,6 +91,7 @@ def generate_launch_description():
             )
         ),
         launch_arguments={
+            'use_synthetic_perception': use_synthetic_perception,
             'use_synthetic_odometry': use_synthetic_odometry,
         }.items(),
     )
@@ -103,6 +108,13 @@ def generate_launch_description():
             'use_synthetic_odometry',
             default_value='false',
             description='Forward synthetic odometry flag to mapping launch.',
+        ),
+        DeclareLaunchArgument(
+            'use_synthetic_perception',
+            default_value='false',
+            description=(
+                'Use mapping synthetic perception instead of real YOLO/UFLD.'
+            ),
         ),
         control,
         synthetic_actuation_feedback,


### PR DESCRIPTION
Problem
For software-only AP1 integration testing, full_system.launch.py can start perception, mapping, planning, and control, but the stack still needs odometry and actuation feedback publishers. Without those, planner/control can stall before hardware is available.

Changes
- Add use_synthetic_odometry launch argument and forward it to mapping_pipeline.launch.py.
- Add use_synthetic_actuation_feedback launch argument.
- Start ap1_control/synthetic_actuation_feedback_node when that flag is enabled.

Example
ros2 launch ap1_bringup full_system.launch.py use_synthetic_odometry:=true use_synthetic_actuation_feedback:=true

Dependencies
- mapping-and-localization#11 provides the synthetic /slam_odom publisher behind use_synthetic_odometry.
- control#12 provides synthetic_actuation_feedback_node.

Test plan
- python3 -m py_compile src/bringup/launch/full_system.launch.py
- git diff --check