### PR TITLE
test: add bag and software smoke validation scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,3 +3,46 @@
 This is for scripts.
 
 `perception_setup.sh` is for getting perceptions dependencies in order. If on a fresh machine run it. Must be ubuntu.
+
+## Software smoke test
+
+`software_smoke_test.sh` validates the AP1 software stack up to the hardware
+boundary using synthetic inputs:
+
+```bash
+AP1_WORKSPACE=~/weap/ap1 ./scripts/software_smoke_test.sh
+```
+
+It checks that these topics publish at least once:
+
+```text
+/ap1/mapping/odometer
+/ap1/mapping/entities
+/ap1/mapping/lanes
+/ap1/planning/target_path
+/ap1/control/motor_power
+/ap1/control/turn_angle
+```
+
+This requires the software smoke-test PRs that add synthetic perception,
+synthetic odometry, synthetic actuation feedback, and full-system launch flags.
+
+## RealSense IMU bag summary
+
+`realsense_imu_bag_summary.py` summarizes accel/gyro streams in a RealSense
+`.bag` file:
+
+```bash
+cd ~/weap/ap1/src/perception
+.venv/bin/python ~/weap/ap1/scripts/realsense_imu_bag_summary.py \
+  /mnt/c/Users/LukeB/Downloads/20260323_151704.bag
+```
+
+The `20260323_151704.bag` recording is motion-only. It can validate accel/gyro
+sample counts, timestamps, axes, bias, and IMU fusion experiments. It cannot
+exercise RGB/depth perception, lanes, entities, or point-cloud projection.
+
+Current blocker: `realsense2_camera` can fail on IMU-only bags with
+`No known base_stream found for transformations`, so use `pyrealsense2`
+directly until AP1 has a dedicated IMU bag publisher or IMU-to-odometry fusion
+node.

--- a/scripts/realsense_imu_bag_summary.py
+++ b/scripts/realsense_imu_bag_summary.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Summarize accel/gyro streams in a RealSense .bag file."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+
+import pyrealsense2 as rs
+
+
+def stream_name(frame: rs.frame) -> str:
+    """Return a stable stream name for a RealSense frame."""
+    return str(frame.profile.stream_type()).replace('stream.', '')
+
+
+def summarize_bag(path: Path, timeout_ms: int) -> None:
+    """Read a RealSense bag and print stream/sample statistics."""
+    config = rs.config()
+    rs.config.enable_device_from_file(config, str(path), repeat_playback=False)
+
+    pipe = rs.pipeline()
+    profile = pipe.start(config)
+    playback = profile.get_device().as_playback()
+    playback.set_real_time(False)
+
+    print(f'bag: {path}')
+    print(f'device: {profile.get_device().get_info(rs.camera_info.name)}')
+    print('streams:')
+    for stream_profile in profile.get_streams():
+        stream_type = stream_profile.stream_type()
+        if stream_type in (rs.stream.color, rs.stream.depth, rs.stream.infrared):
+            video_profile = stream_profile.as_video_stream_profile()
+            print(
+                '  '
+                f'{stream_type} {stream_profile.format()} '
+                f'{video_profile.width()}x{video_profile.height()} '
+                f'@ {stream_profile.fps()} Hz'
+            )
+        else:
+            print(
+                '  '
+                f'{stream_type} {stream_profile.format()} '
+                f'@ {stream_profile.fps()} Hz'
+            )
+
+    counts: Counter[str] = Counter()
+    first_ts: dict[str, float] = {}
+    last_ts: dict[str, float] = {}
+    first_values: dict[str, tuple[float, float, float]] = {}
+    last_values: dict[str, tuple[float, float, float]] = {}
+
+    try:
+        while True:
+            frames = pipe.wait_for_frames(timeout_ms)
+            for frame in frames:
+                name = stream_name(frame)
+                counts[name] += 1
+                timestamp = frame.get_timestamp()
+                first_ts.setdefault(name, timestamp)
+                last_ts[name] = timestamp
+                if frame.is_motion_frame():
+                    motion = frame.as_motion_frame().get_motion_data()
+                    value = (motion.x, motion.y, motion.z)
+                    first_values.setdefault(name, value)
+                    last_values[name] = value
+    except RuntimeError as exc:
+        print(f'end/read timeout: {exc}')
+    finally:
+        pipe.stop()
+
+    print('sample summary:')
+    for name in sorted(counts):
+        duration_sec = (last_ts[name] - first_ts[name]) / 1000.0
+        approx_hz = (
+            (counts[name] - 1) / duration_sec if duration_sec > 0.0 else 0.0
+        )
+        print(
+            f'  {name}: count={counts[name]} '
+            f'duration={duration_sec:.3f}s approx_hz={approx_hz:.2f} '
+            f'first={first_values.get(name)} last={last_values.get(name)}'
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Summarize RealSense accel/gyro streams from a .bag file.'
+    )
+    parser.add_argument('bag', type=Path)
+    parser.add_argument('--timeout-ms', type=int, default=5000)
+    args = parser.parse_args()
+
+    summarize_bag(args.bag.expanduser().resolve(), args.timeout_ms)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/software_smoke_test.sh
+++ b/scripts/software_smoke_test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Software-only AP1 smoke test.
+#
+# This validates the stack up to the hardware boundary by using synthetic
+# perception, synthetic odometry, and synthetic actuation feedback. It expects
+# the workspace to include the related smoke-test PRs for mapping/control/AP1.
+
+WORKSPACE="${AP1_WORKSPACE:-$HOME/weap/ap1}"
+LOG_DIR="${AP1_SMOKE_LOG_DIR:-/tmp/ap1-smoke}"
+STARTUP_SEC="${AP1_SMOKE_STARTUP_SEC:-8}"
+TOPIC_TIMEOUT_SEC="${AP1_SMOKE_TOPIC_TIMEOUT_SEC:-8}"
+
+mkdir -p "$LOG_DIR"
+
+cleanup() {
+    if [[ -f "$LOG_DIR/full_system.pid" ]]; then
+        local pid
+        pid="$(cat "$LOG_DIR/full_system.pid")"
+        kill "$pid" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+cd "$WORKSPACE"
+
+set +u
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+set -u
+
+ros2 launch ap1_bringup full_system.launch.py \
+    use_synthetic_perception:=true \
+    use_synthetic_odometry:=true \
+    use_synthetic_actuation_feedback:=true \
+    > "$LOG_DIR/full_system.log" 2>&1 &
+echo "$!" > "$LOG_DIR/full_system.pid"
+
+sleep "$STARTUP_SEC"
+
+check_topic_once() {
+    local topic="$1"
+    local output_name="$2"
+    local output_path="$LOG_DIR/$output_name"
+
+    if timeout "${TOPIC_TIMEOUT_SEC}s" ros2 topic echo --once "$topic" \
+        > "$output_path" 2>&1; then
+        echo "PASS $topic"
+    else
+        echo "FAIL $topic"
+        cat "$output_path"
+        return 1
+    fi
+}
+
+check_topic_once /ap1/mapping/odometer odometer.txt
+check_topic_once /ap1/mapping/entities entities.txt
+check_topic_once /ap1/mapping/lanes lanes.txt
+check_topic_once /ap1/planning/target_path target_path.txt
+check_topic_once /ap1/control/motor_power motor_power.txt
+check_topic_once /ap1/control/turn_angle turn_angle.txt
+
+ros2 node list > "$LOG_DIR/nodes.txt"
+ros2 topic list | sort > "$LOG_DIR/topics.txt"
+
+echo
+echo "Smoke test passed. Logs: $LOG_DIR"


### PR DESCRIPTION
﻿Problem
We have two useful test paths right now, but they were only documented in chat/manual commands:

- software-only AP1 smoke testing up to the hardware boundary
- RealSense IMU-only bag validation for motion data

The motion-only RealSense bag cannot exercise RGB/depth perception, and the full software stack needs synthetic odometry/actuation feedback until real hardware or sim feedback exists.

Changes
- Add scripts/software_smoke_test.sh to validate the synthetic software stack publishes:
  - /ap1/mapping/odometer
  - /ap1/mapping/entities
  - /ap1/mapping/lanes
  - /ap1/planning/target_path
  - /ap1/control/motor_power
  - /ap1/control/turn_angle
- Add scripts/realsense_imu_bag_summary.py to summarize accel/gyro streams from a RealSense .bag file using pyrealsense2.
- Update scripts/README.md with usage, expected coverage, and the IMU-only bag blocker.

Validation
- bash -n scripts/software_smoke_test.sh
- python -m py_compile scripts/realsense_imu_bag_summary.py
- git diff --check
- Ran the IMU summary script on /mnt/c/Users/LukeB/Downloads/20260323_151704.bag:
  - Device: Intel RealSense D455
  - Streams: gyro + accel only
  - gyro samples: 4768
  - accel samples: 4768
  - no RGB/depth/point cloud streams
- Software smoke test was verified locally after applying the dependent smoke-test branches: odometer, mapping lanes/entities, planner target_path, and control motor/turn outputs all published.

Known blocker
realsense2_camera currently fails on the IMU-only bag with: No known base_stream found for transformations. For that bag, use pyrealsense2 directly until AP1 has a dedicated IMU bag publisher or IMU-to-odometry fusion node.

Dependencies
The software smoke test expects the synthetic smoke-test PRs to be merged first, especially mapping-and-localization#10/#11/#12, control#12, planning#17, and ap1#25.
